### PR TITLE
adiciona parâmetro de estado a pl das armas e do lobby

### DIFF
--- a/src/components/card/expanded/rede/Tooltip.vue
+++ b/src/components/card/expanded/rede/Tooltip.vue
@@ -4,7 +4,7 @@
     :class="classObj"
     :y="20"
     :x="0"
-  >{{ node.nome_eleitoral }}
+  >{{ node.nome + " (" + node.partido + "/" + node.uf + ")" }}
   </text>
 </template>
 


### PR DESCRIPTION
Solução de emergência :)

Obs.: A api retorna o nome eleitoral com todos os dados, mas por algum motivo, no frontend, não recupera o dado após a /, pois o padrão é: nome do parlamentar (partido/estado). 

O dado completo na api:
![image](https://user-images.githubusercontent.com/18709508/73389095-36400a80-42b2-11ea-9b19-47cd4fa779c5.png)
