### PR TITLE
Remove passos desnecessários no pipeline do CI do gitlab.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,11 +9,9 @@ stages:
 
 variables:
   DOCKER_HOST: tcp://docker:2375/
-  DOCKER_DRIVER: overlay2
   COMPOSE_CMD: docker-compose -f docker_extra/prod.yml
   COMPOSE_BUILDER_CMD: docker-compose -f docker_extra/builder.yml
   FRONTEND_ADDR: "http://frontend:80"  # usada pelo compose de test
-  DOCKER_TLS_CERTDIR: ""
 
 before_script:
   - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,6 @@ services:
 stages:
   - build
   - test
-  - deploy
 
 variables:
   DOCKER_HOST: tcp://docker:2375/
@@ -19,11 +18,8 @@ variables:
 before_script:
   - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
   - if [ "$CI_COMMIT_REF_NAME" = "production" ]; then export SUFIX="prod"; else export SUFIX="dev"; fi
-  - export CANDIDATE_IMAGE="$CI_REGISTRY_IMAGE:cadidate-$SUFIX"
-  - export FRONTEND_IMAGE_TAG="$CANDIDATE_IMAGE"  # usada pelo compose de prod
   - export FRONTEND_BUILDER_IMAGE_TAG="$CI_REGISTRY_IMAGE:builder-$SUFIX"
   - export FRONTEND_TEST_IMAGE_TAG="$CI_REGISTRY_IMAGE:test-$SUFIX"
-  - export RELEASE_IMAGE="$CI_REGISTRY_IMAGE:release-$SUFIX"
 
 build:
   stage: build
@@ -45,25 +41,3 @@ tests:
     - npm run docker_test
     - $COMPOSE_CMD down
     - docker push $FRONTEND_TEST_IMAGE_TAG
-
-.release_and_deploy: &rd
-  stage: deploy
-  script:
-    - docker pull $CANDIDATE_IMAGE
-    - docker tag $CANDIDATE_IMAGE $RELEASE_IMAGE
-    - docker push $RELEASE_IMAGE
-    - curl --fail -XPOST "$WEBHOOK"
-
-deploy_dev:
-  <<: *rd
-  variables:
-    WEBHOOK: $DEPLOY_WEBHOOK_DEVELOPMENT
-  only:
-    - master
-
-deploy_prod:
-  <<: *rd
-  variables:
-    WEBHOOK: $DEPLOY_WEBHOOK
-  only:
-    - production

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,8 +17,9 @@ variables:
 
 before_script:
   - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
-  - docker login docker.io
   - if [ "$CI_COMMIT_REF_NAME" = "production" ]; then export SUFIX="prod"; else export SUFIX="dev"; fi
+  - export CANDIDATE_IMAGE="$CI_REGISTRY_IMAGE:cadidate-$SUFIX"	
+  - export FRONTEND_IMAGE_TAG="$CANDIDATE_IMAGE"  # usada pelo compose de prod
   - export FRONTEND_BUILDER_IMAGE_TAG="$CI_REGISTRY_IMAGE:builder-$SUFIX"
   - export FRONTEND_TEST_IMAGE_TAG="$CI_REGISTRY_IMAGE:test-$SUFIX"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ variables:
 
 before_script:
   - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+  - docker login docker.io
   - if [ "$CI_COMMIT_REF_NAME" = "production" ]; then export SUFIX="prod"; else export SUFIX="dev"; fi
   - export FRONTEND_BUILDER_IMAGE_TAG="$CI_REGISTRY_IMAGE:builder-$SUFIX"
   - export FRONTEND_TEST_IMAGE_TAG="$CI_REGISTRY_IMAGE:test-$SUFIX"


### PR DESCRIPTION
## Mudanças
- Torna pipeline do CI no gitlab mais eficiente:
  + Remove passos desnecessários (release e deploy, que eram usados quando usávamos o Portainer pra fazer o deploy da aplicação a partir da VM)
  + Remove variáveis desnecessárias (que eram usadas nos passos removidos ou que eram redundantes)
  + Deixa apenas etapa de build, que já contém o teste.


## Como Testar
- O teste que valida o pipeline é o resultado da execução no gitlab. Se ele cumpre os requisitos necessários (build e teste) e passa no gitlab, então está ok.