### PR TITLE
Passa a considerar atributos do interesse da proposição

### DIFF
--- a/src/components/card/ProposicaoExpanded.vue
+++ b/src/components/card/ProposicaoExpanded.vue
@@ -42,6 +42,8 @@
       <p class="small-text-field small-margin-top">{{ getNomeAutor() }}</p>
       <p class="medium-text-field small-margin-top">{{ prop.lastEtapa.relator_nome }}</p>
       <p class="small-text-field small-margin-top">Relator(a)</p>
+      <p v-if="temTipoAgenda" class="medium-text-field small-margin-top">{{ tipoAgendaFormatado }}</p>
+      <p v-if="temTipoAgenda" class="small-text-field small-margin-top">Tipo da Agenda</p>
     </div>
 
     <h2>Temperatura e Pressão</h2>
@@ -236,6 +238,20 @@ export default {
     },
     emPauta () {
       return this.etapa.emPauta
+    },
+    temTipoAgenda() {
+      const tipoAgenda = this.prop.tipo_agenda
+      return tipoAgenda !== 'nan' && tipoAgenda !== null
+    },
+    tipoAgendaFormatado() {
+      const tipoAgenda = this.prop.tipo_agenda
+      if (tipoAgenda === 'positiva') {
+        return 'Positiva'
+      } else if (tipoAgenda === 'negativa'){
+        return 'Negativa'
+      } else {
+        return 'Não avaliada'
+      }
     },
     ...mapState({
       dateRef: state => state.filter.dateRef,

--- a/src/components/card/ProposicaoExpanded.vue
+++ b/src/components/card/ProposicaoExpanded.vue
@@ -42,8 +42,12 @@
       <p class="small-text-field small-margin-top">{{ getNomeAutor() }}</p>
       <p class="medium-text-field small-margin-top">{{ prop.lastEtapa.relator_nome }}</p>
       <p class="small-text-field small-margin-top">Relator(a)</p>
-      <p v-if="temTipoAgenda" class="medium-text-field small-margin-top">{{ tipoAgendaFormatado }}</p>
-      <p v-if="temTipoAgenda" class="small-text-field small-margin-top">Tipo da Agenda</p>
+      <p
+        v-if="temTipoAgenda"
+        class="medium-text-field small-margin-top">{{ tipoAgendaFormatado }}</p>
+      <p
+        v-if="temTipoAgenda"
+        class="small-text-field small-margin-top">Tipo da Agenda</p>
     </div>
 
     <h2>Temperatura e Pressão</h2>
@@ -239,15 +243,15 @@ export default {
     emPauta () {
       return this.etapa.emPauta
     },
-    temTipoAgenda() {
+    temTipoAgenda () {
       const tipoAgenda = this.prop.tipo_agenda
       return tipoAgenda !== 'nan' && tipoAgenda !== null
     },
-    tipoAgendaFormatado() {
+    tipoAgendaFormatado () {
       const tipoAgenda = this.prop.tipo_agenda
       if (tipoAgenda === 'positiva') {
         return 'Positiva'
-      } else if (tipoAgenda === 'negativa'){
+      } else if (tipoAgenda === 'negativa') {
         return 'Negativa'
       } else {
         return 'Não avaliada'

--- a/src/components/card/ProposicaoHeader.vue
+++ b/src/components/card/ProposicaoHeader.vue
@@ -36,7 +36,7 @@
     />
     <bar
       class="pressao"
-      :ultimo_valor="prop.ultima_pressao"
+      :ultimo_valor="prop.ultima_pressao*100"
       :cor="'#FFAB0F'"
       :max_valor="100"
       :tooltip-texto="'Pressão da Semana'"/>

--- a/src/components/card/ProposicaoItem.vue
+++ b/src/components/card/ProposicaoItem.vue
@@ -34,7 +34,8 @@ export default {
       return {
         name: 'proposicao',
         params: {
-          id_leggo: this.prop.id_leggo
+          id_leggo: this.prop.id_leggo,
+          slug_interesse: this.prop.interesse[0].interesse
         }
       }
     }

--- a/src/components/card/expanded/Graphics.vue
+++ b/src/components/card/expanded/Graphics.vue
@@ -4,7 +4,8 @@
       :temp_historico="prop.temperatura_historico"
       :id="prop.id_leggo" />
     <pressure-graphic
-      :id="prop.id_leggo" />
+      :id="prop.id_leggo"
+      :interesse="prop.interesse[0].interesse" />
   </el-col>
 </template>
 

--- a/src/components/card/expanded/pressao/PressureGraphic.vue
+++ b/src/components/card/expanded/pressao/PressureGraphic.vue
@@ -45,6 +45,10 @@ export default {
     id: {
       type: Number,
       default: 0
+    },
+    interesse: {
+      type: String,
+      default: 'leggo'
     }
   },
   computed: {
@@ -89,7 +93,7 @@ export default {
   async mounted () {
     try {
       await this.getPressao({
-        params: { idLeggo: this.id }
+        params: { idLeggo: this.id, interesse: this.interesse }
       })
     } catch (exc) {
       this.composicao = undefined

--- a/src/router.js
+++ b/src/router.js
@@ -95,9 +95,10 @@ const router = new Router({
       component: ProposicaoDetailed,
       props: true,
       beforeEnter: async ({ params }, from, next) => {
+        const interesse = store.state.proposicoes.interesse
         let prop = store.state.proposicoes.proposicoes.filter(e => e.id_leggo === parseInt(params.id_leggo))[0]
         if (!prop.detailed) {
-          await store.dispatch('detailProposicao', { params: { idLeggo: prop.id_leggo } })
+          await store.dispatch('detailProposicao', { params: { idLeggo: prop.id_leggo, interesse } })
           prop = store.state.proposicoes.proposicoes.filter(e => e.id_leggo === parseInt(params.id_leggo))[0]
         }
         params.prop = prop

--- a/src/router.js
+++ b/src/router.js
@@ -90,15 +90,16 @@ const router = new Router({
       }
     },
     {
-      path: '/proposicao/:id_leggo/:slug_interesse',
+      path: '/proposicao/:id_leggo/:slug_interesse?',
       name: 'proposicao',
       component: ProposicaoDetailed,
       props: true,
       beforeEnter: async ({ params }, from, next) => {
-        store.state.proposicoes.interesse = params.slug_interesse
+        let interesse = params.slug_interesse || store.state.proposicoes.interesse || 'leggo'
+        store.state.proposicoes.interesse = interesse
+
         const semanas = store.state.filter.semanas
         const date = store.getters.formattedDateRef
-        const interesse = params.slug_interesse
         const proposicoes = store.state.proposicoes.proposicoes
         if (proposicoes.length === 0) {
           await store.dispatch('listProposicoes', { params: { semanas, date, interesse } })

--- a/src/stores/pressao.js
+++ b/src/stores/pressao.js
@@ -10,8 +10,8 @@ const pressao = new Vapi({
   } }).get({
   action: 'getPressao',
   property: 'pressao',
-  path: ({ idLeggo }) =>
-    `pressao/${idLeggo}`,
+  path: ({ idLeggo, interesse }) =>
+    `pressao/${idLeggo}?interesse=${interesse}`,
   onSuccess: (state, { data }, axios, { params }) => {
     Vue.set(state.pressao, params.idLeggo, data)
   }

--- a/src/stores/proposicoes.js
+++ b/src/stores/proposicoes.js
@@ -37,7 +37,7 @@ const proposicoes = new Vapi({
       prop.status = retornaProposicaoComStatusGeral(prop)
       prop.firstEtapa = prop.etapas.slice(0, 1)[0]
       prop.lastEtapa = prop.etapas.slice(-1)[0]
-      
+
       prop.detailed = false
       temperaturas[prop.id_leggo] = prop.ultima_temperatura
       ultimasPressoes[prop.id_leggo] = prop.ultima_pressao
@@ -45,7 +45,7 @@ const proposicoes = new Vapi({
       pautasTmp[prop.lastEtapa.id] = prop.lastEtapa.pauta_historico
     })
     state.proposicoes = data
-    
+
     Vue.set(temps.state, 'temperaturas', temperaturas)
     Vue.set(temps.state, 'coeficiente', coeficientes)
     Vue.set(pautas.state, 'pautas', pautasTmp)

--- a/src/stores/proposicoes.js
+++ b/src/stores/proposicoes.js
@@ -32,6 +32,7 @@ const proposicoes = new Vapi({
       prop.apelido = prop.interesse[0].apelido
       prop.sigla = prop.etapas[0].sigla
       prop.advocacy_link = prop.interesse[0].advocacy_link
+      prop.tipo_agenda = prop.interesse[0].tipo_agenda
 
       // TODO: por enquanto usa apenas a última etapa
       prop.status = retornaProposicaoComStatusGeral(prop)
@@ -61,6 +62,7 @@ const proposicoes = new Vapi({
     dataProp.apelido = dataProp.interesse[0].apelido
     dataProp.sigla = dataProp.etapas[0].sigla
     dataProp.advocacy_link = dataProp.interesse[0].advocacy_link
+    dataProp.tipo_agenda = dataProp.interesse[0].tipo_agenda
 
     dataProp.firstEtapa = dataProp.etapas.slice(0, 1)[0]
     dataProp.lastEtapa = dataProp.etapas.slice(-1)[0]
@@ -94,7 +96,7 @@ proposicoes.getters = {
     options['temas'] = new Set()
     if (state.proposicoes.length !== 0) {
       for (let prop of state.proposicoes) {
-        for (let tema of prop.lastEtapa['temas']) {
+        for (let tema of prop['temas']) {
           options['temas'].add(tema)
         }
       }

--- a/src/stores/proposicoes.js
+++ b/src/stores/proposicoes.js
@@ -23,22 +23,29 @@ const proposicoes = new Vapi({
   path: ({ semanas, date, interesse }) =>
     `proposicoes?semanas_anteriores=${semanas}&data_referencia=${date}&interesse=${interesse}`,
   onSuccess: (state, { data }) => {
-    state.proposicoes = data
     let temperaturas = {}
     let coeficientes = {}
     let pautasTmp = {}
     let ultimasPressoes = {}
     data.forEach((prop) => {
+      prop.temas = prop.interesse[0].temas
+      prop.apelido = prop.interesse[0].apelido
+      prop.sigla = prop.etapas[0].sigla
+      prop.advocacy_link = prop.interesse[0].advocacy_link
+
       // TODO: por enquanto usa apenas a última etapa
       prop.status = retornaProposicaoComStatusGeral(prop)
       prop.firstEtapa = prop.etapas.slice(0, 1)[0]
       prop.lastEtapa = prop.etapas.slice(-1)[0]
+      
       prop.detailed = false
       temperaturas[prop.id_leggo] = prop.ultima_temperatura
       ultimasPressoes[prop.id_leggo] = prop.ultima_pressao
       coeficientes[prop.id_leggo] = prop.temperatura_coeficiente
       pautasTmp[prop.lastEtapa.id] = prop.lastEtapa.pauta_historico
     })
+    state.proposicoes = data
+    
     Vue.set(temps.state, 'temperaturas', temperaturas)
     Vue.set(temps.state, 'coeficiente', coeficientes)
     Vue.set(pautas.state, 'pautas', pautasTmp)
@@ -46,10 +53,15 @@ const proposicoes = new Vapi({
   }
 }).get({
   action: 'detailProposicao',
-  path: ({ idLeggo }) =>
-    `proposicoes/${idLeggo}`,
+  path: ({ idLeggo, interesse }) =>
+    `proposicoes/${idLeggo}?interesse=${interesse}`,
   onSuccess: (state, { data }) => {
     const dataProp = data[0]
+    dataProp.temas = dataProp.interesse[0].temas
+    dataProp.apelido = dataProp.interesse[0].apelido
+    dataProp.sigla = dataProp.etapas[0].sigla
+    dataProp.advocacy_link = dataProp.interesse[0].advocacy_link
+
     dataProp.firstEtapa = dataProp.etapas.slice(0, 1)[0]
     dataProp.lastEtapa = dataProp.etapas.slice(-1)[0]
     const last = dataProp.lastEtapa

--- a/src/stores/proposicoes.js
+++ b/src/stores/proposicoes.js
@@ -33,6 +33,7 @@ const proposicoes = new Vapi({
       prop.sigla = prop.etapas[0].sigla
       prop.advocacy_link = prop.interesse[0].advocacy_link
       prop.tipo_agenda = prop.interesse[0].tipo_agenda
+      prop.ultima_pressao = prop.interesse[0].ultima_pressao
 
       // TODO: por enquanto usa apenas a última etapa
       prop.status = retornaProposicaoComStatusGeral(prop)
@@ -63,6 +64,7 @@ const proposicoes = new Vapi({
     dataProp.sigla = dataProp.etapas[0].sigla
     dataProp.advocacy_link = dataProp.interesse[0].advocacy_link
     dataProp.tipo_agenda = dataProp.interesse[0].tipo_agenda
+    dataProp.ultima_pressao = dataProp.interesse[0].ultima_pressao
 
     dataProp.firstEtapa = dataProp.etapas.slice(0, 1)[0]
     dataProp.lastEtapa = dataProp.etapas.slice(-1)[0]

--- a/src/views/Proposicoes.vue
+++ b/src/views/Proposicoes.vue
@@ -3,7 +3,7 @@
     <filter-button />
     <ultimos-eventos/>
     <p v-if="pending.proposicoes">Carregando proposições <i class="el-icon-loading"/></p>
-    <p v-else-if="error.proposicoes">Falha no carregamento</p>    
+    <p v-else-if="error.proposicoes">Falha no carregamento</p>
     <transition
       v-else
       name="el-fade-in"

--- a/src/views/Proposicoes.vue
+++ b/src/views/Proposicoes.vue
@@ -75,7 +75,12 @@ export default {
 
     checkCategoricalFilters (prop) {
       return this.filter.filters.every(
-        filter => this.getCurrent[filter].length === 0 || this.filter.current[filter].some(v => prop[filter].includes(v))
+        filter => this.getCurrent[filter].length === 0 || this.filter.current[filter].some(v => {
+          if (prop[filter]) {
+            return prop[filter].includes(v)
+          }
+          return prop.lastEtapa[filter].includes(v)
+        })
       )
     },
     checkPautaFilter (prop) {
@@ -85,7 +90,7 @@ export default {
       return (!this.filter.emPautaFilter.some(options => options.status) ? true : emPauta)
     },
     checkStatusFilter (prop) {
-      return this.filter.showFinalizadas.status || prop.status === ''
+      return this.filter.showFinalizadas.status || prop.status === 'Ativa'
     },
     checkApelidoFilter (prop) {
       const apelido = removeAcentos(prop.sigla.toLowerCase() + prop.apelido.toLowerCase())
@@ -94,7 +99,7 @@ export default {
     },
     checkPropMatchesFilter (prop) {
       return this.checkCategoricalFilters(prop) &&
-        this.checkPautaFilter(prop)
+        this.checkPautaFilter(prop.lastEtapa)
     },
     updateSticky (refHeader, refSession) {
       if (!refSession || !refHeader) return
@@ -125,8 +130,8 @@ export default {
       // Teste para ver se o obj com os filtros já foi inicializado
       if (Object.keys(this.getCurrent).length) {
         return this.proposicoes.filter(prop => {
-          return this.checkPropMatchesFilter(prop.lastEtapa) &&
-          this.checkStatusFilter(prop) && this.checkApelidoFilter(prop)
+          return this.checkPropMatchesFilter(prop) &&
+          this.checkStatusFilter(prop.lastEtapa) && this.checkApelidoFilter(prop)
         }).sort((a, b) => {
           let idA = a.lastEtapa.id
           let idB = b.lastEtapa.id

--- a/src/views/Proposicoes.vue
+++ b/src/views/Proposicoes.vue
@@ -3,7 +3,7 @@
     <filter-button />
     <ultimos-eventos/>
     <p v-if="pending.proposicoes">Carregando proposições <i class="el-icon-loading"/></p>
-    <p v-else-if="error.proposicoes">Falha no carregamento</p>
+    <p v-else-if="error.proposicoes">Falha no carregamento</p>    
     <transition
       v-else
       name="el-fade-in"
@@ -94,8 +94,7 @@ export default {
     },
     checkPropMatchesFilter (prop) {
       return this.checkCategoricalFilters(prop) &&
-        this.checkPautaFilter(prop) &&
-        this.checkApelidoFilter(prop)
+        this.checkPautaFilter(prop)
     },
     updateSticky (refHeader, refSession) {
       if (!refSession || !refHeader) return
@@ -127,7 +126,7 @@ export default {
       if (Object.keys(this.getCurrent).length) {
         return this.proposicoes.filter(prop => {
           return this.checkPropMatchesFilter(prop.lastEtapa) &&
-          this.checkStatusFilter(prop)
+          this.checkStatusFilter(prop) && this.checkApelidoFilter(prop)
         }).sort((a, b) => {
           let idA = a.lastEtapa.id
           let idB = b.lastEtapa.id


### PR DESCRIPTION
## Mudanças
- Ajusta objeto da licitação para recuperar informações do tema, apelido, tipo_agenda diretamente do interesse selecionado para a proposição
- Ajusta componente de filtro ao novo formato da proposição

## Flags
- Funciona com a versão do backend proposta pelo PR https://github.com/parlametria/leggo-backend/pull/170 e gerada pelo leggoR https://github.com/parlametria/leggoR/pull/536
- Assume que o PR https://github.com/parlametria/leggo-frontend/pull/453 foi revisado e aprovado
- Assume que o PR https://github.com/parlametria/leggo-frontend/pull/454 foi revisado e aprovado