### PR TITLE
Exibe mensagem quando últimos eventos não forem retornados

### DIFF
--- a/src/components/card/expanded/EventosInfo.vue
+++ b/src/components/card/expanded/EventosInfo.vue
@@ -33,6 +33,9 @@
         </div>
       </table>
     </div>
+    <div v-else>
+      <span>Ainda não foram capturados eventos para esta proposição.</span>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
## Mudanças
- Exibe mensagem quando últimos eventos não forem retornados

## Flags 
- É possível testar alterando o atributo nivel da query de últimos eventos para o valor 0 (`linha 126 do arquivo  src/components/card/expanded/EventosInfo.vue`)
