### PR TITLE
Aumenta nível dos eventos que podem ser recuperados na aba de últimos eventos

### DIFF
--- a/src/components/UltimosEventos.vue
+++ b/src/components/UltimosEventos.vue
@@ -22,7 +22,7 @@
         </td>
         <td>
           <div class="evento-title">
-            <span>{{ evento.titulo }}</span> - <router-link :to="{ name: 'proposicao', params: { id_leggo: evento.propId }}">{{ evento.propName }}</router-link>
+            <span>{{ evento.titulo }}</span> - <router-link :to="{ name: 'proposicao', params: { id_leggo: evento.propId, slug_interesse: evento.interesse }}">{{ evento.propName }}</router-link>
           </div>
           <div>
             {{ evento.texto }}
@@ -50,19 +50,24 @@ export default {
       proposicoes: state => state.proposicoes.proposicoes
     }),
     ...mapGetters([
-      'getPropById'
+      'getPropById',
+      'getInteresse'
     ]),
     procEventos () {
       if (this.ultimosEventos) {
         return this.ultimosEventos.map(evento => {
           var prop = this.getPropById(evento.proposicao_id)
-          var propName = prop ? prop.apelido : ''
+          let propName = ''
+          if (prop) {
+            propName = prop.apelido !== 'nan' ? prop.apelido : prop.lastEtapa.sigla
+          }
           return {
             data: evento.data,
             propId: evento.proposicao_id,
             texto: evento.texto_tramitacao,
             local: evento.sigla_local,
             titulo: evento.titulo_evento,
+            interesse: prop.interesse[0].interesse,
             propName
           }
         })
@@ -76,7 +81,7 @@ export default {
   },
   mounted () {
     if (!this.ultimosEventos || !this.ultimosEventos.length) {
-      this.getUltimosEventos({ params: { nivel: 1, ultimosN: 10 } })
+      this.getUltimosEventos({ params: { nivel: 1, ultimosN: 10, interesse: this.getInteresse } })
     }
   }
 }

--- a/src/components/card/expanded/EventosInfo.vue
+++ b/src/components/card/expanded/EventosInfo.vue
@@ -84,7 +84,7 @@ export default {
             dataDiff: this.formatDateDifference(eventoTram.data),
             sigla:
               eventoTram.sigla_local === 'nan' ? '' : eventoTram.sigla_local,
-            title: eventoTram.titulo_evento,
+            title: eventoTram.titulo_evento === 'nan' ? '' : eventoTram.titulo_evento,
             texto: this.formatTextoTramitacao(
               eventoTram.texto_tramitacao,
               index, this.MAX_TEXT_LENGTH, this.TEXT_TO_BE_SHOWED_LENGTH
@@ -123,7 +123,7 @@ export default {
           casa: this.casa,
           id: this.id,
           dataFim: moment(this.date).format('YYYY-MM-DD'),
-          nivel: 1,
+          nivel: 3,
           ultimosN: 3
         }
       }

--- a/src/components/card/expanded/EventosInfo.vue
+++ b/src/components/card/expanded/EventosInfo.vue
@@ -33,6 +33,9 @@
         </div>
       </table>
     </div>
+    <div v-else>
+      <span>Ainda não foram capturados eventos para esta proposição.</span>
+    </div>
   </div>
 </template>
 

--- a/src/stores/eventos_tramitacao.js
+++ b/src/stores/eventos_tramitacao.js
@@ -20,7 +20,7 @@ const eventosTramitacao = new Vapi({
 }).get({
   action: 'getUltimosEventos',
   property: 'ultimosEventos',
-  path: ({ nivel, ultimosN }) => `eventos_tramitacao/?nivel=${nivel}&ultimos_n=${ultimosN}`
+  path: ({ nivel, ultimosN, interesse }) => `eventos_tramitacao/?nivel=${nivel}&ultimos_n=${ultimosN}&interesse=${interesse}`
 }).getStore()
 
 export default eventosTramitacao

--- a/src/stores/proposicoes.js
+++ b/src/stores/proposicoes.js
@@ -15,7 +15,8 @@ const proposicoes = new Vapi({
     tramitacoes: new Set(),
     eventos_tramitacao: {},
     metaInfo: {},
-    interesse: ''
+    interesse: '',
+    nome_interesse: ''
   }
 }).get({
   action: 'listProposicoes',
@@ -27,6 +28,12 @@ const proposicoes = new Vapi({
     let coeficientes = {}
     let pautasTmp = {}
     let ultimasPressoes = {}
+
+    // Define nome do interesse das proposições
+    if (data && data.length > 0) {
+      state.nome_interesse = data[0].interesse[0].nome_interesse
+    }
+
     data.forEach((prop) => {
       prop.temas = prop.interesse[0].temas
       prop.apelido = prop.interesse[0].apelido
@@ -111,6 +118,9 @@ proposicoes.getters = {
   },
   getInteresse (state) {
     return state.interesse
+  },
+  getNomeInteresse (state) {
+    return state.nome_interesse
   }
 }
 

--- a/src/views/Proposicoes.vue
+++ b/src/views/Proposicoes.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="content">
+    <span class="interesse">{{ getNomeInteresse }}</span>
     <filter-button />
     <!-- <ultimos-eventos/> -->
     <p v-if="pending.proposicoes">Carregando proposições <i class="el-icon-loading"/></p>
@@ -125,7 +126,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['perFilterOptions', 'formattedDateRef', 'getCurrent']),
+    ...mapGetters(['perFilterOptions', 'formattedDateRef', 'getCurrent', 'getNomeInteresse']),
     filteredProps () {
       // Teste para ver se o obj com os filtros já foi inicializado
       if (Object.keys(this.getCurrent).length) {
@@ -236,5 +237,12 @@ export default {
   display: flex;
   flex-direction: column;
   align-items: stretch;
+}
+.interesse {
+  display: block;
+  font-weight: normal;
+  font-size: 1.8rem;
+  margin-bottom: 1.5rem;
+  color: #656565;
 }
 </style>

--- a/src/views/Proposicoes.vue
+++ b/src/views/Proposicoes.vue
@@ -2,7 +2,7 @@
   <div class="content">
     <span class="interesse">{{ getNomeInteresse }}</span>
     <filter-button />
-    <!-- <ultimos-eventos/> -->
+    <ultimos-eventos/>
     <p v-if="pending.proposicoes">Carregando proposições <i class="el-icon-loading"/></p>
     <p v-else-if="error.proposicoes">Falha no carregamento</p>
     <transition


### PR DESCRIPTION
## Mudanças
- Aumenta nível dos eventos que podem ser recuperados na aba de últimos eventos. Assume que a ordenação da API já leva em consideração exibir os eventos mais relevantes primeiro (considerando corte dos ultimos_n).
- Corrige título de eventos sem título

## Flags
- Assume que o PR https://github.com/parlametria/leggo-frontend/pull/465 foi revisado e aprovado
- Deve ser revisado em conjunto com o PR https://github.com/parlametria/leggo-backend/pull/175