### PR TITLE
Calibrar a temperatura por interesse / agenda

### DIFF
--- a/src/components/card/ProposicaoHeader.vue
+++ b/src/components/card/ProposicaoHeader.vue
@@ -40,14 +40,14 @@
       :ultimo_valor="prop.ultima_temperatura"
       :cor="'#9b5498'"
       :max_valor="maxTemperatura"
-      :tooltip-texto="'Temperatura da Semana'"
+      :tooltip-texto="'Temperatura da semana: ' + prop.ultima_temperatura"
     />
     <bar
       class="pressao"
       :ultimo_valor="prop.ultima_pressao*100"
       :cor="'#FFAB0F'"
       :max_valor="100"
-      :tooltip-texto="'Pressão da Semana'"/>
+      :tooltip-texto="(prop.ultima_pressao < 0) ? 'Pressão da semana: --' : 'Pressão da semana: ' + prop.ultima_pressao*100"/>
   </div>
 </template>
 

--- a/src/components/card/expanded/temperature/TemperatureGraphic.vue
+++ b/src/components/card/expanded/temperature/TemperatureGraphic.vue
@@ -16,6 +16,7 @@
 import TemperatureGraphicModel from './TemperatureGraphicModel.js'
 import TemperatureInfo from './TemperatureInfo'
 import moment from 'moment'
+import { mapGetters } from 'vuex'
 
 export default {
   name: 'TemperatureGraphic',
@@ -29,9 +30,14 @@ export default {
       default () {
         return []
       }
+    },
+    max_temperatura: {
+      type: Number,
+      default: 100
     }
   },
   computed: {
+    ...mapGetters(['maxTemperatura']),
     temperaturas () {
       if (this.temp_historico) {
         return this.temp_historico.filter(
@@ -65,7 +71,7 @@ export default {
   methods: {
     async mountGraphic () {
       if (this.verificaSeMostraTemperatura && this.temperaturas && this.temperaturas.length) {
-        let model = new TemperatureGraphicModel(this.tamanhoGrafico)
+        let model = new TemperatureGraphicModel(this.tamanhoGrafico, this.maxTemperatura)
         await // eslint-disable-next-line
         (await vegaEmbed(this.$refs.anchor, model.vsSpec)).view
           .change(

--- a/src/components/card/expanded/temperature/TemperatureGraphicModel.js
+++ b/src/components/card/expanded/temperature/TemperatureGraphicModel.js
@@ -1,5 +1,5 @@
 export default class TemperatureGraphicModel {
-  constructor (width) {
+  constructor (width, maxTemperatura) {
     this.vsSpec = {
       description: 'Últimos 30 dias',
       $schema: 'https://vega.github.io/schema/vega-lite/v3.3.0.json',
@@ -42,7 +42,7 @@ export default class TemperatureGraphicModel {
             labels: false,
             ticks: false
           },
-          scale: { domain: [0, 100] }
+          scale: { domain: [0, maxTemperatura] }
         },
         tooltip: [
           { 'field': 'temperatura_recente', 'type': 'quantitative', 'title': 'Temperatura' },

--- a/src/router.js
+++ b/src/router.js
@@ -106,6 +106,7 @@ const router = new Router({
 
         const semanas = store.state.filter.semanas
         const date = store.getters.formattedDateRef
+        const dataInicio = moment(date).subtract(3, 'months').format('YYYY-MM-DD')
         const proposicoes = store.state.proposicoes.proposicoes
         if (proposicoes.length === 0) {
           await store.dispatch('listProposicoes', { params: { semanas, date, interesse } })
@@ -116,6 +117,9 @@ const router = new Router({
           await store.dispatch('detailProposicao', { params: { idLeggo: prop.id_leggo, interesse } })
           prop = store.state.proposicoes.proposicoes.filter(e => e.id_leggo === parseInt(params.id_leggo))[0]
         }
+        await store.dispatch('maxTemperatura', {
+          params: { interesse, dataInicio }
+        })
         params.prop = prop
         next()
       }

--- a/src/router.js
+++ b/src/router.js
@@ -11,6 +11,7 @@ import Relatorios from '@/views/Relatorios'
 import Semanarios from '@/views/Semanarios'
 import store from '@/stores/store'
 import NProgress from 'nprogress'
+import moment from 'moment'
 
 Vue.use(Router)
 
@@ -54,11 +55,16 @@ const router = new Router({
         NProgress.start()
         const semanas = store.state.filter.semanas
         const date = store.getters.formattedDateRef
+        const dataInicio = moment(date).subtract(3, 'months').format('YYYY-MM-DD')
         const interesse = 'leggo'
         const proposicoes = store.state.proposicoes.proposicoes
+
         if (proposicoes.length === 0) {
           await store.dispatch('listProposicoes', {
             params: { semanas, date, interesse }
+          })
+          await store.dispatch('maxTemperatura', {
+            params: { interesse, dataInicio }
           })
         }
         NProgress.done()
@@ -130,11 +136,16 @@ const router = new Router({
         NProgress.start()
         const semanas = store.state.filter.semanas
         const date = store.getters.formattedDateRef
+        const dataInicio = moment(date).subtract(3, 'months').format('YYYY-MM-DD')
         const interesse = params.slug_interesse
         const proposicoes = store.state.proposicoes.proposicoes
+
         if (proposicoes.length === 0) {
           await store.dispatch('listProposicoes', {
             params: { semanas, date, interesse }
+          })
+          await store.dispatch('maxTemperatura', {
+            params: { interesse, dataInicio }
           })
         }
         NProgress.done()

--- a/src/stores/proposicoes.js
+++ b/src/stores/proposicoes.js
@@ -16,7 +16,8 @@ const proposicoes = new Vapi({
     eventos_tramitacao: {},
     metaInfo: {},
     interesse: '',
-    nome_interesse: ''
+    nome_interesse: '',
+    maxTemperatura: 0
   }
 }).get({
   action: 'listProposicoes',
@@ -85,6 +86,14 @@ const proposicoes = new Vapi({
     state.proposicoes = props
   }
 }).get({
+  action: 'maxTemperatura',
+  property: 'maxTemperatura',
+  path: ({ interesse, dataInicio }) =>
+    `temperatura/max?interesse=${interesse}&data_inicio=${dataInicio}`,
+  onSuccess: (state, { data }) => {
+    state.maxTemperatura = data.max_temperatura_periodo
+  }
+}).get({
   action: 'getMetaInfo',
   path: '/info',
   property: 'metaInfo'
@@ -126,6 +135,9 @@ proposicoes.getters = {
   },
   getNomeInteresse (state) {
     return state.nome_interesse
+  },
+  maxTemperatura (state) {
+    return state.maxTemperatura
   }
 }
 

--- a/src/stores/temperaturas.js
+++ b/src/stores/temperaturas.js
@@ -13,19 +13,6 @@ const temperaturas = {
     setCoeficiente (state, { id, coeficiente }) {
       state.coeficiente[id] = coeficiente
     }
-  },
-  getters: {
-    maxTemperatura (state) {
-      const temperaturas = state.temperaturas
-      let maxTemperatura = 0
-      Object.keys(temperaturas).forEach(function (key) {
-        let temperatura = temperaturas[key]
-        if (temperatura && temperatura > maxTemperatura) {
-          maxTemperatura = temperatura
-        }
-      })
-      return maxTemperatura === 0 ? 10 : maxTemperatura
-    }
   }
 }
 export default temperaturas

--- a/src/views/Proposicoes.vue
+++ b/src/views/Proposicoes.vue
@@ -71,7 +71,7 @@ export default {
     }
   },
   methods: {
-    ...mapActions(['listProposicoes']),
+    ...mapActions(['listProposicoes', 'maxTemperatura']),
     ...mapMutations(['setPageNumber']),
 
     checkCategoricalFilters (prop) {


### PR DESCRIPTION
## Mudanças

- Recupera a temperatura máxima do backend
- Calibra a escala das barras da lista e do detalhe das temperaturas de acordo com essa máxima
- Exibe no tooltip de temperatura e pressão o valor atual

## Flags

Considera que o [PR#179](https://github.com/parlametria/leggo-backend/pull/179) do legoo-backend foi aprovado