### PR TITLE
Adiciona componente de Anotações na tela detalhada de uma proposição

### DIFF
--- a/src/components/card/ProposicaoExpanded.vue
+++ b/src/components/card/ProposicaoExpanded.vue
@@ -101,6 +101,12 @@
           :date="dateRef"/>
       </div>
     </div>
+    <div class="sessao">
+      <h2>Anotações mais recentes</h2>
+      <anotacao-prop
+        :id="prop.id_leggo"
+        :date="dateRef" />
+    </div>
     <div>
       <pautas-info
         :id="prop.lastEtapa.id_ext"
@@ -124,6 +130,8 @@ import EventosInfo from './expanded/EventosInfo'
 import ComposicaoLink from './expanded/ComposicaoLink'
 import PautasInfo from './expanded/PautasInfo'
 import AuthorName from './expanded/AuthorName'
+import AnotacaoProp from './expanded/anotacao/AnotacaoPorProposicao'
+
 import { mapState } from 'vuex'
 import moment from 'moment'
 
@@ -152,7 +160,8 @@ export default {
     EventosInfo,
     ComposicaoLink,
     PautasInfo,
-    AuthorName
+    AuthorName,
+    AnotacaoProp
   },
   methods: {
     hasNumber (myString) {

--- a/src/components/card/ProposicaoExpanded.vue
+++ b/src/components/card/ProposicaoExpanded.vue
@@ -69,6 +69,11 @@
       />
     </div>
     <div class="sessao">
+      <anotacao-prop
+        :id="prop.id_leggo"
+        :date="dateRef" />
+    </div>
+    <div class="sessao">
       <h2>Últimos Eventos</h2>
       <eventos-info
         :id="prop.lastEtapa.id_ext"
@@ -100,12 +105,6 @@
           :casa="getCasa(etapa)"
           :date="dateRef"/>
       </div>
-    </div>
-    <div class="sessao">
-      <h2>Anotações mais recentes</h2>
-      <anotacao-prop
-        :id="prop.id_leggo"
-        :date="dateRef" />
     </div>
     <div>
       <pautas-info

--- a/src/components/card/expanded/anotacao/AnotacaoPorProposicao.vue
+++ b/src/components/card/expanded/anotacao/AnotacaoPorProposicao.vue
@@ -113,7 +113,6 @@ export default {
       return {
         params: {
           id: this.id,
-          peso: 3,
           ultimasN: 10,
           interesse: this.getInteresse
         }

--- a/src/components/card/expanded/anotacao/AnotacaoPorProposicao.vue
+++ b/src/components/card/expanded/anotacao/AnotacaoPorProposicao.vue
@@ -94,7 +94,6 @@ export default {
       let groups = {}
       let groupName
       this.formattedAnotacoes.forEach(anotacao => {
-        console.log(anotacao)
         groupName = anotacao.data
         if (!groups[groupName]) {
           groups[groupName] = []
@@ -105,7 +104,6 @@ export default {
       for (groupName in groups) {
         myArray.push({ group: groupName, anotacao: groups[groupName] })
       }
-      console.log(myArray)
       return myArray
     },
     ...mapState({

--- a/src/components/card/expanded/anotacao/AnotacaoPorProposicao.vue
+++ b/src/components/card/expanded/anotacao/AnotacaoPorProposicao.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <div v-if="formattedAnotacoes.length">
+      <h2>Insights</h2>
       <table class="tabela-anotacoes-prop">
         <div
           v-for="(anotacao, key) in formattedAnotacoes"
@@ -33,9 +34,6 @@
           </td>
         </div>
       </table>
-    </div>
-    <div v-else>
-      <span>Ainda não foram adicionadas anotações à esta proposição.</span>
     </div>
   </div>
 </template>

--- a/src/components/card/expanded/anotacao/AnotacaoPorProposicao.vue
+++ b/src/components/card/expanded/anotacao/AnotacaoPorProposicao.vue
@@ -1,0 +1,204 @@
+<template>
+  <div>
+    <div v-if="formattedAnotacoes.length">
+      <table class="tabela-anotacoes-prop">
+        <div
+          v-for="(anotacao, key) in formattedAnotacoes"
+          :key="key">
+          <td class="date-field">
+            {{ anotacao.autor }}
+            <tr class="autor-anotacao">
+              <el-tooltip
+                :content="anotacao.dataModificacao"
+                placement="bottom">
+                <div>{{ anotacao.dataModificacaoDiff }}</div>
+              </el-tooltip>
+            </tr>
+          </td>
+
+          <td>
+            <tr
+              class="titulo-anotacao"
+            > {{ anotacao.titulo }} </tr>
+            <tr
+              :class="{ clickable: anotacao.collapsible }"
+              @click="toggleCollapseDescription(key)"
+            >
+              {{ anotacao.texto }}
+            </tr>
+            <span
+              v-if="!isExpanded(key) && anotacao.collapsible"
+              class="el-icon-circle-plus-outline"
+            />
+          </td>
+        </div>
+      </table>
+    </div>
+    <div v-else>
+      <span>Ainda não foram adicionadas anotações à esta proposição.</span>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapState, mapGetters } from 'vuex'
+import moment from 'moment'
+import mixin from '@/mixins/ExpandedTexts.js'
+
+export default {
+  name: 'AnotacaoProp',
+  data () {
+    return {
+      MAX_TEXT_LENGTH: 200,
+      TEXT_TO_BE_SHOWED_LENGTH: 50
+    }
+  },
+  mixins: [mixin],
+  props: {
+    id: {
+      type: Number,
+      default: undefined
+    },
+    date: {
+      type: Date,
+      default: function () {
+        return new Date()
+      }
+    }
+  },
+  mounted () {
+    if (!this.formattedAnotacoes.length) {
+      this.getAnotacoesByProp(this.query)
+    }
+  },
+  computed: {
+    ...mapGetters(['getInteresse']),
+    formattedAnotacoes () {
+      return (this.anotacoesProp[this.id] || []).map((anotacao, index) => {
+        return {
+          dataModificacao: this.formatDate(anotacao.data_ultima_modificacao),
+          dataModificacaoDiff: this.formatDateDifference(anotacao.data_ultima_modificacao),
+          dataCriacao: this.formatDate(anotacao.data_criacao),
+          dataCriacaoDiff: this.formatDateDifference(anotacao.data_criacao),
+          autor: anotacao.autor === 'nan' ? '' : anotacao.autor,
+          titulo: anotacao.titulo === 'nan' ? '' : anotacao.titulo,
+          texto: this.formatTextoTramitacao(
+            anotacao.anotacao,
+            index,
+            this.MAX_TEXT_LENGTH,
+            this.TEXT_TO_BE_SHOWED_LENGTH
+          ),
+          collapsible: anotacao.anotacao.length > this.MAX_TEXT_LENGTH
+        }
+      })
+    },
+    groupAnotacoes () {
+      let groups = {}
+      let groupName
+      this.formattedAnotacoes.forEach(anotacao => {
+        console.log(anotacao)
+        groupName = anotacao.data
+        if (!groups[groupName]) {
+          groups[groupName] = []
+        }
+        groups[groupName].push(anotacao)
+      })
+      let myArray = []
+      for (groupName in groups) {
+        myArray.push({ group: groupName, anotacao: groups[groupName] })
+      }
+      console.log(myArray)
+      return myArray
+    },
+    ...mapState({
+      anotacoesProp: state => state.anotacoes.anotacoesProp
+    }),
+    query () {
+      return {
+        params: {
+          id: this.id,
+          peso: 3,
+          ultimasN: 10,
+          interesse: this.getInteresse
+        }
+      }
+    }
+  },
+  methods: {
+    ...mapActions(['getAnotacoesByProp']),
+    formatDateDifference (date) {
+      const formattedDate = moment(this.formatDate(date), moment.ISO_8601)
+      const differenceInDays = moment().diff(formattedDate, 'days')
+      const differenceInMinutes = moment().diff(formattedDate, 'minutes')
+      let dateInTextFormat = `Há ${differenceInDays} dias`
+
+      if (differenceInDays > 365) {
+        const differenceInYears = Math.floor(differenceInDays / 365)
+        dateInTextFormat =
+          differenceInYears === 1
+            ? 'Há ± 1 ano'
+            : `Há ± ${differenceInYears} anos`
+      } else if (differenceInDays > 30) {
+        const differenceInMonths = Math.floor(differenceInDays / 30)
+        dateInTextFormat =
+          differenceInMonths === 1
+            ? 'Há ± 1 mês'
+            : `Há ± ${differenceInMonths} meses`
+      } else if (differenceInDays <= 1) {
+        if (differenceInMinutes >= 60) {
+          const differenceInHours = Math.floor(differenceInMinutes / 60)
+          dateInTextFormat = `Há ± ${differenceInHours} h`
+        } else {
+          dateInTextFormat = `Há ± ${differenceInMinutes} min`
+        }
+      }
+
+      return dateInTextFormat
+    },
+    formatDate (date) {
+      return date.replace('T', ' ').replace('Z', '')
+    }
+  },
+  watch: {
+    date () {
+      this.getAnotacoesByProp(this.query)
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+@import "@/base.scss";
+.el-collapse {
+  margin-top: 1rem;
+}
+.tabela-anotacoes-prop {
+  font-size: 10pt;
+}
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+th,
+td {
+  padding: 0.5rem;
+  text-align: left;
+  vertical-align: top;
+}
+.date-field {
+  width: 100px;
+  white-space: nowrap;
+  padding-right: 2rem;
+}
+.titulo-anotacao {
+  width: 100%;
+  font-weight: bold;
+  text-transform: capitalize;
+}
+.autor-anotacao {
+  color: #999;
+}
+.el-icon-circle-plus-outline {
+  color: $--color-primary;
+}
+</style>

--- a/src/stores/anotacoes.js
+++ b/src/stores/anotacoes.js
@@ -12,8 +12,8 @@ const anotacoes = new Vapi({
 }).get({
   action: 'getAnotacoesByProp',
   property: 'anotacoesProp',
-  path: ({ id, peso, ultimasN, interesse }) =>
-    `anotacoes/${id}?peso=${peso}&ultimas_n=${ultimasN}&interesse=${interesse}`,
+  path: ({ id, ultimasN, interesse }) =>
+    `anotacoes/${id}?&ultimas_n=${ultimasN}&interesse=${interesse}`,
   onSuccess: (state, { data }, axios, { params }) => {
     Vue.set(state.anotacoesProp, params.id, data)
   }

--- a/src/stores/anotacoes.js
+++ b/src/stores/anotacoes.js
@@ -1,0 +1,26 @@
+import Vue from 'vue'
+import Vapi from 'vuex-rest-api'
+import axios from './axios'
+
+const anotacoes = new Vapi({
+  axios: axios,
+  baseURL: process.env.VUE_APP_API_URL,
+  state: {
+    anotacoesProp: {},
+    ultimasAnotacoes: []
+  }
+}).get({
+  action: 'getAnotacoesByProp',
+  property: 'anotacoesProp',
+  path: ({ id, peso, ultimasN, interesse }) =>
+    `anotacoes/${id}?peso=${peso}&ultimas_n=${ultimasN}&interesse=${interesse}`,
+  onSuccess: (state, { data }, axios, { params }) => {
+    Vue.set(state.anotacoesProp, params.id, data)
+  }
+}).get({
+  action: 'getUltimasAnotacoes',
+  property: 'ultimasAnotacoes',
+  path: ({ peso, ultimasN, interesse }) => `anotacoes/?peso=${peso}&ultimas_n=${ultimasN}&interesse=${interesse}`
+}).getStore()
+
+export default anotacoes

--- a/src/stores/store.js
+++ b/src/stores/store.js
@@ -9,6 +9,7 @@ import emendasStore from './emendas'
 import comissoesStore from './comissoes'
 import authStore from './auth'
 import pressaoStore from './pressao'
+import anotacaoStore from './anotacoes'
 
 Vue.use(Vuex)
 
@@ -22,6 +23,7 @@ export default new Vuex.Store({
     emendas: emendasStore,
     comissoes: comissoesStore,
     auth: authStore,
-    pressao: pressaoStore
+    pressao: pressaoStore,
+    anotacoes: anotacaoStore
   }
 })


### PR DESCRIPTION
**Mudanças propostas neste PR:**
- Adiciona store e componente de anotações por proposição e interesse à tela detalhada das proposições;
- Um exemplo de url que retorna anotações diferentes sobre uma proposição (pela versão dev da planilha) pode ser encontrada em `http://localhost:3000/#/proposicao/1/primeira-infancia`.

**OBS:** Esta versão necessita da branch `1801-anotacoes-mais-recentes` do [leggo-backend](https://github.com/parlametria/leggo-backend).
