### PR TITLE
Adiciona link para documentos de análises do Congresso Remoto

### DIFF
--- a/src/components/header/NavigationButtons.vue
+++ b/src/components/header/NavigationButtons.vue
@@ -33,7 +33,11 @@
         :to="{ name: 'semanarios' }"><span @click="closeMenu">Semanário</span></router-link-->
       <router-link
         :to="{ name: 'ajuda' }"><span @click="closeMenu">Ajuda</span></router-link>
+      <router-link
+        v-if="getInteresse === 'congresso-remoto'"
+        :to="{ name: 'analises' }"><span>Análises</span></router-link>
       <a
+        v-if="getInteresse !== 'congresso-remoto'"
         href="https://parlametria.github.io/leggo-frontend/"
         target="_blank"><span>Relatórios</span></a>
       <!-- <router-link

--- a/src/router.js
+++ b/src/router.js
@@ -4,6 +4,7 @@ import Proposicoes from '@/views/Proposicoes.vue'
 import Sobre from '@/views/Sobre.vue'
 import Cases from '@/views/Cases.vue'
 import Ajuda from '@/views/Ajuda.vue'
+import Analises from '@/views/Analises.vue'
 import Comissao from '@/views/Comissao.vue'
 import AtoresDetailed from '@/views/AtoresDetailed.vue'
 import ProposicaoDetailed from '@/views/ProposicaoDetailed.vue'
@@ -39,6 +40,11 @@ const router = new Router({
       path: '/relatorios',
       name: 'relatorios',
       component: Relatorios
+    },
+    {
+      path: '/analises',
+      name: 'analises',
+      component: Analises
     },
     {
       path: '/semanarios',

--- a/src/views/Analises.vue
+++ b/src/views/Analises.vue
@@ -1,0 +1,43 @@
+<template>
+  <div>
+    <h2>Análises</h2>
+    <h3>Boletins Congresso Remoto</h3>
+    <ul class="links">
+      <li><span class="links-item">Boletim 1</span> <a href="#">O processo legislativo na deliberação remota</a></li>
+    </ul>
+    <h3>Congresso Remoto em Notas</h3>
+    <ul class="links">
+      <li><span class="links-item">Nota 1</span> <a href="#">O que virou lei na pandemia?</a></li>
+      <li><span class="links-item">Nota 2</span> <a href="#">O quórum do Congresso no período remoto</a></li>
+      <li><span class="links-item">Nota 3</span> <a href="#">Medidas provisórias durante a pandemia</a></li>
+    </ul>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Analises'
+}
+</script>
+
+<style lang="scss" scoped>
+@import "@/base.scss";
+
+.links {
+  list-style: none;
+  margin-bottom: 2rem;
+}
+
+.links > li {
+  padding-top: .5rem;
+  padding-bottom: .5rem;
+}
+
+.links-item {
+  width: 80px;
+  display: inline-block;
+  font-weight: bold;
+  text-align: right;
+  margin-right: 1rem;
+}
+</style>

--- a/src/views/Analises.vue
+++ b/src/views/Analises.vue
@@ -3,13 +3,33 @@
     <h2>Análises</h2>
     <h3>Boletins Congresso Remoto</h3>
     <ul class="links">
-      <li><span class="links-item">Boletim 1</span> <a href="#">O processo legislativo na deliberação remota</a></li>
+      <li>
+        <span class="links-item">Boletim 1</span>
+        <a
+          href="https://drive.google.com/file/d/1dC1nQgS9DFf1VOPZDYRHOhUV3h-aCSQp/view?usp=sharing"
+          target="_blank">O processo legislativo na deliberação remota</a>
+      </li>
     </ul>
     <h3>Congresso Remoto em Notas</h3>
     <ul class="links">
-      <li><span class="links-item">Nota 1</span> <a href="#">O que virou lei na pandemia?</a></li>
-      <li><span class="links-item">Nota 2</span> <a href="#">O quórum do Congresso no período remoto</a></li>
-      <li><span class="links-item">Nota 3</span> <a href="#">Medidas provisórias durante a pandemia</a></li>
+      <li>
+        <span class="links-item">Nota 1</span>
+        <a
+          href="https://drive.google.com/file/d/1fH15K8EUJGiv1yLfQuQxsjJDkN6mE0lL/view?usp=sharing"
+          target="_blank">O que virou lei na pandemia?</a>
+      </li>
+      <li>
+        <span class="links-item">Nota 2</span>
+        <a
+          href="https://drive.google.com/file/d/1XosUBKbnazOMcSZ-5C-AgxJsh0uL88hV/view?usp=sharing"
+          target="_blank">O quórum do Congresso no período remoto</a>
+      </li>
+      <li>
+        <span class="links-item">Nota 3</span>
+        <a
+          href="https://drive.google.com/file/d/1T5q-SLCHu2SXTb1RkeY6_sM9cYIdX9D4/view?usp=sharing"
+          target="_blank">Medidas provisórias durante a pandemia</a>
+      </li>
     </ul>
   </div>
 </template>


### PR DESCRIPTION
## Mudanças

- Troca o link de **RELATÓRIOS** para **ANÁLISES** caso a agenda seja **congresso-remoto**
- Os links devem apontar para documentos reais, hospedados no Google Drive