### PR TITLE
Refletir mudanças do tipo do campo id_leggo

### DIFF
--- a/src/components/card/EtapaProposicao.vue
+++ b/src/components/card/EtapaProposicao.vue
@@ -21,8 +21,8 @@ export default {
   },
   props: {
     id_leggo: {
-      type: Number,
-      default: -1
+      type: String,
+      default: '-1'
     },
     etapa: {
       type: Object,

--- a/src/components/card/expanded/anotacao/AnotacaoPorProposicao.vue
+++ b/src/components/card/expanded/anotacao/AnotacaoPorProposicao.vue
@@ -53,7 +53,7 @@ export default {
   mixins: [mixin],
   props: {
     id: {
-      type: Number,
+      type: String,
       default: undefined
     },
     date: {

--- a/src/components/card/expanded/atores/TabAtoresGraphics.vue
+++ b/src/components/card/expanded/atores/TabAtoresGraphics.vue
@@ -36,8 +36,8 @@ export default {
       default: ''
     },
     id_leggo: {
-      type: Number,
-      default: -1
+      type: String,
+      default: '-1'
     },
     apelido: {
       type: String,

--- a/src/components/card/expanded/pressao/PressureGraphic.vue
+++ b/src/components/card/expanded/pressao/PressureGraphic.vue
@@ -43,8 +43,8 @@ export default {
   name: 'PressureGraphic',
   props: {
     id: {
-      type: Number,
-      default: 0
+      type: String,
+      default: undefined
     },
     interesse: {
       type: String,

--- a/src/components/card/expanded/rede/Autorias.vue
+++ b/src/components/card/expanded/rede/Autorias.vue
@@ -23,8 +23,8 @@ export default {
       default: null
     },
     id_leggo: {
-      type: Number,
-      default: 0
+      type: String,
+      default: '0'
     }
   },
   data () {

--- a/src/components/card/expanded/rede/PesoPoliticoGraph.vue
+++ b/src/components/card/expanded/rede/PesoPoliticoGraph.vue
@@ -46,8 +46,8 @@ export default {
   mixins: [legendas],
   props: {
     id_leggo: {
-      type: Number,
-      default: 0
+      type: String,
+      default: '0'
     }
   },
   data() {

--- a/src/components/card/expanded/temperature/TemperatureGraphic.vue
+++ b/src/components/card/expanded/temperature/TemperatureGraphic.vue
@@ -22,7 +22,7 @@ export default {
   name: 'TemperatureGraphic',
   props: {
     id: {
-      type: Number,
+      type: String,
       default: undefined
     },
     temp_historico: {

--- a/src/components/card/expanded/temperature/TemperatureInfo.vue
+++ b/src/components/card/expanded/temperature/TemperatureInfo.vue
@@ -58,7 +58,7 @@ export default {
   name: 'TemperatureInfo',
   props: {
     id: {
-      type: Number,
+      type: String,
       default: undefined
     },
     mostraTooltip: {

--- a/src/router.js
+++ b/src/router.js
@@ -117,11 +117,11 @@ const router = new Router({
         if (proposicoes.length === 0) {
           await store.dispatch('listProposicoes', { params: { semanas, date, interesse } })
         }
-        let prop = store.state.proposicoes.proposicoes.filter(e => e.id_leggo === parseInt(params.id_leggo))[0]
+        let prop = store.state.proposicoes.proposicoes.filter(e => e.id_leggo === params.id_leggo)[0]
 
         if (!prop.detailed) {
           await store.dispatch('detailProposicao', { params: { idLeggo: prop.id_leggo, interesse } })
-          prop = store.state.proposicoes.proposicoes.filter(e => e.id_leggo === parseInt(params.id_leggo))[0]
+          prop = store.state.proposicoes.proposicoes.filter(e => e.id_leggo === params.id_leggo)[0]
         }
         await store.dispatch('maxTemperatura', {
           params: { interesse, dataInicio }

--- a/src/views/AtoresDetailed.vue
+++ b/src/views/AtoresDetailed.vue
@@ -22,8 +22,8 @@ export default {
   name: 'AtoresDetailed',
   props: {
     id_leggo: {
-      type: Number,
-      default: -1
+      type: String,
+      default: '-1'
     },
     apelido: {
       type: String,


### PR DESCRIPTION
** Mudanças deste PR: **

- Adequa código para refletir as mudanças do  tipo do campo id_leggo;

**OBS:** Para testar é necessário estar na branch [2066-modificar-campo-id_leggo](https://github.com/parlametria/leggo-backend/tree/2066-modificar-campo-id_leggo) do leggo-backend.