### PR TITLE
2124 - Adapta front para siglas

### DIFF
--- a/src/components/card/ProposicaoExpanded.vue
+++ b/src/components/card/ProposicaoExpanded.vue
@@ -8,13 +8,35 @@
     <div class="portal">
       <p
         class="small-text-field"
-        v-for="(etapa,i) in prop.etapas"
-        :key="i">
+        v-if="prop.sigla_camara !== null && prop.sigla_senado !== null">
         <a
           class="sigla"
-          :href="etapa.url"
-          target="_blank">{{ etapa.sigla }}</a>
-        - {{ $t(etapa.casa) }}
+          :href="prop.url"
+          target="_blank">{{ prop.sigla_camara }}</a>
+        - Câmara
+        <a
+          class="sigla"
+          :href="prop.url"
+          target="_blank">{{ prop.sigla_senado }}</a>
+        - Senado
+      </p>
+      <p
+        class="small-text-field"
+        v-else-if="prop.sigla_camara !== null && prop.sigla_senado === null">
+        <a
+          class="sigla"
+          :href="prop.url"
+          target="_blank">{{ prop.sigla_camara }}</a>
+        - Câmara
+      </p>
+      <p
+        class="small-text-field"
+        v-else>
+        <a
+          class="sigla"
+          :href="prop.url"
+          target="_blank">{{ prop.sigla_senado }}</a>
+        - Senado
       </p>
     </div>
     <div class="container pl-actions">

--- a/src/stores/proposicoes.js
+++ b/src/stores/proposicoes.js
@@ -76,6 +76,7 @@ const proposicoes = new Vapi({
 
     dataProp.firstEtapa = dataProp.etapas.slice(0, 1)[0]
     dataProp.lastEtapa = dataProp.etapas.slice(-1)[0]
+    dataProp.url = dataProp.lastEtapa.url
     const last = dataProp.lastEtapa
     store.commit('setTemperatura', { id_leggo: last['id_leggo'], temperatura: last['temperatura_historico'] })
     store.commit('setCoeficiente', { id_leggo: last['id_leggo'], coeficiente: last['temperatura_coeficiente'] })


### PR DESCRIPTION
Essa alteração visa adaptar o frontend para receber as siglas das proposições diretamente e não mais através de suas etapas.

Alterações essas feitas na branch [2123](https://github.com/parlametria/leggo-backend/pull/279).