### PR TITLE
Adiciona apt-get update na criação da imagem de teste

### DIFF
--- a/docker_extra/test.dockerfile
+++ b/docker_extra/test.dockerfile
@@ -1,4 +1,5 @@
 FROM cypress/base:10
+RUN apt-get update
 RUN apt-get --assume-yes install openbsd-inetd netcat
 WORKDIR /app
 RUN npm install cypress


### PR DESCRIPTION
## Mudanças
- Adiciona apt-get update na criação da imagem de teste. 

Com este PR o pipeline de build e test no gitlab volta a funcionar corretamente.