### PR TITLE
Passa a recuperar de endpoint específico a informação da última anotação feita para as proposições monitoradas

### DIFF
--- a/src/stores/anotacoes.js
+++ b/src/stores/anotacoes.js
@@ -8,7 +8,8 @@ const anotacoes = new Vapi({
   state: {
     anotacoesProp: {},
     ultimasAnotacoes: [],
-    ultimasAnotacoesGerais: []
+    ultimasAnotacoesGerais: [],
+    dataUltimasAnotacoes: []
   }
 }).get({
   action: 'getAnotacoesByProp',
@@ -26,6 +27,14 @@ const anotacoes = new Vapi({
   action: 'getUltimasAnotacoesGerais',
   property: 'ultimasAnotacoesGerais',
   path: ({ peso, ultimasN, interesse }) => `anotacoes-gerais/?peso=${peso}&ultimas_n=${ultimasN}&interesse=${interesse}`
+}).get({
+  action: 'getUltimasDatasAnotacoes',
+  property: 'dataUltimasAnotacoes',
+  path: ({ interesse }) =>
+    `anotacoes/ultima?interesse=${interesse}`,
+  onSuccess: (state, { data }, axios, { params }) => {
+    Vue.set(state.dataUltimasAnotacoes, data)
+  }
 }).getStore()
 
 export default anotacoes

--- a/src/stores/proposicoes.js
+++ b/src/stores/proposicoes.js
@@ -72,6 +72,17 @@ const proposicoes = new Vapi({
       state.proposicoes = data
     })
 
+    store.dispatch('getUltimasDatasAnotacoes', {
+      params: { interesse }
+    }).then((payload) => {
+      data = data.map(a => ({
+        ...payload.data.find(p => a.id_leggo === p.id_leggo),
+        ...a
+      }))
+
+      state.proposicoes = data
+    })
+
     Vue.set(pautas.state, 'pautas', pautasTmp)
   }
 }).get({


### PR DESCRIPTION
## Mudanças
- Passa a recuperar de endpoint específico a informação da última anotação feita para as proposições monitoradas

## Flags
- Depende da versão do leggo-backend https://github.com/parlametria/leggo-backend/pull/287