### PR TITLE
2218 - Adapta navegação da proposição

### DIFF
--- a/src/components/UltimosEventos.vue
+++ b/src/components/UltimosEventos.vue
@@ -1,5 +1,14 @@
 <template>
   <div v-if="procEventos.length">
+    <h2
+      :class="'link-site'">
+      <a
+        :href="'https://leggo-painel.parlametria.org.br/' + getInteresse">
+        <span>
+          Acesso ao novo Parlametria
+        </span>
+      </a>
+    </h2>
     <div
       class="title"
       @click="show = !show">
@@ -130,6 +139,11 @@ th, td {
   color: $--color-primary;
 }
 .title {
+  cursor: pointer;
+}
+.link-site {
+  text-align: center;
+  text-decoration: underline;
   cursor: pointer;
 }
 </style>

--- a/src/components/header/NavigationButtons.vue
+++ b/src/components/header/NavigationButtons.vue
@@ -1,8 +1,8 @@
 <template>
   <nav class="navbar navbar-light navbar-expand-md">
     <div class="container">
-      <router-link
-        :to="{ name: 'proposicoes' }"
+      <a
+        :href="'https://leggo-painel.parlametria.org.br/' + getInteresse + '/proposicoes'"
         :class="'navbar-brand'">
         <img
           class="logo"
@@ -13,7 +13,7 @@
         <span>
           • Painel {{ getNomeInteresse }}
         </span>
-      </router-link>
+      </a>
       <button
         class="navbar-toggler"
         type="button"
@@ -29,21 +29,13 @@
         class="collapse navbar-collapse"
         :class="{ show: openMenu }">
         <ul class="navbar-nav ml-auto">
-          <li
-            class="nav-item"
-            v-if="getInteresse === 'leggo'">
-            <router-link
-              :to="{ name: 'proposicoes' }"><span @click="closeMenu">Proposições</span></router-link>
-          </li>
-          <li
-            class="nav-item"
-            v-if="getInteresse !== 'leggo'">
-            <router-link
-              :to="{ name: 'interesse', params: { slug_interesse: getInteresse } }"><span @click="closeMenu">Proposições</span></router-link>
+          <li class="nav-item">
+            <a
+              :href="'https://leggo-painel.parlametria.org.br/' + getInteresse + '/proposicoes'"><span>Proposições</span></a>
           </li>
           <li class="nav-item">
             <a
-              :href="'https://leggo-painel.parlametria.org.br/' + getInteresse"><span>Parlamentares</span></a>
+              :href="'https://leggo-painel.parlametria.org.br/' + getInteresse + '/atores-chave'"><span>Parlamentares</span></a>
           </li>
           <li class="nav-item">
             <router-link

--- a/src/components/header/NavigationButtons.vue
+++ b/src/components/header/NavigationButtons.vue
@@ -35,7 +35,7 @@
           </li>
           <li class="nav-item">
             <a
-              :href="'https://leggo-painel.parlametria.org.br/' + getInteresse + '/atores-chave'"><span>Parlamentares</span></a>
+              :href="'https://leggo-painel.parlametria.org.br/' + getInteresse + '/parlamentares'"><span>Parlamentares</span></a>
           </li>
           <li class="nav-item">
             <router-link

--- a/src/components/header/ProposicaoPageHeader.vue
+++ b/src/components/header/ProposicaoPageHeader.vue
@@ -5,27 +5,16 @@
       v-if="metaInfo && metaInfo.last_update_trams"
       class="container last-update-date"
     >Atualizado em {{ formattedLastUpdateDate }}</div>
-    <h2
-      :class="'link-site'">
-      <a
-        :href="'https://leggo-painel.parlametria.org.br/' + getInteresse">
-        <span>
-          Acesso ao novo Parlametria
-        </span>
-      </a>
-    </h2>
   </div>
 </template>
 
 <script>
-import { mapState, mapActions, mapGetters } from 'vuex'
+import { mapState, mapActions } from 'vuex'
 import NavigationButtons from '@/components/header/NavigationButtons'
 import moment from 'moment'
-
 export default {
   name: 'ProposicaoPageHeader',
   computed: {
-    ...mapGetters(['getInteresse']),
     ...mapState({
       metaInfo: state => state.proposicoes.metaInfo
     }),
@@ -48,11 +37,7 @@ export default {
 <style lang="scss" scoped>
 @import "@/base.scss";
 a {
-  cursor: pointer;
-}
-.link-site {
-  text-align: center;
-  text-decoration: underline;
+  all: unset;
   cursor: pointer;
 }
 .last-update-date {

--- a/src/components/header/ProposicaoPageHeader.vue
+++ b/src/components/header/ProposicaoPageHeader.vue
@@ -5,17 +5,27 @@
       v-if="metaInfo && metaInfo.last_update_trams"
       class="container last-update-date"
     >Atualizado em {{ formattedLastUpdateDate }}</div>
+    <h2
+      :class="'link-site'">
+      <a
+        :href="'https://leggo-painel.parlametria.org.br/' + getInteresse">
+        <span>
+          Acesso ao novo Parlametria
+        </span>
+      </a>
+    </h2>
   </div>
 </template>
 
 <script>
-import { mapState, mapActions } from 'vuex'
+import { mapState, mapActions, mapGetters } from 'vuex'
 import NavigationButtons from '@/components/header/NavigationButtons'
 import moment from 'moment'
 
 export default {
   name: 'ProposicaoPageHeader',
   computed: {
+    ...mapGetters(['getInteresse']),
     ...mapState({
       metaInfo: state => state.proposicoes.metaInfo
     }),
@@ -38,7 +48,11 @@ export default {
 <style lang="scss" scoped>
 @import "@/base.scss";
 a {
-  all: unset;
+  cursor: pointer;
+}
+.link-site {
+  text-align: center;
+  text-decoration: underline;
   cursor: pointer;
 }
 .last-update-date {

--- a/src/router.js
+++ b/src/router.js
@@ -113,6 +113,7 @@ const router = new Router({
       component: ProposicaoDetailed,
       props: true,
       beforeEnter: async ({ params }, from, next) => {
+        NProgress.start()
         let interesse = params.slug_interesse || store.state.proposicoes.interesse || 'leggo'
         store.state.proposicoes.interesse = interesse
 
@@ -136,6 +137,7 @@ const router = new Router({
           params: { idLeggo: prop.id_leggo, interesse }
         })
         params.prop = prop
+        NProgress.done()
         next()
       }
     },

--- a/src/views/ProposicaoDetailed.vue
+++ b/src/views/ProposicaoDetailed.vue
@@ -5,7 +5,7 @@
       <temas
         class="tema"
         :temas="prop.temas" />
-      <a @click="$router.go(-1)">
+      <a>
         <span
           v-if="prop.apelido !== 'nan'"
           class="titulo">{{ this.prop.apelido }}</span>
@@ -42,25 +42,10 @@ export default {
 <style lang="scss" scoped>
 @import "@/base.scss";
 
-a {
-  cursor: pointer;
-}
 .titulo {
   color: #656565;
   font-size: 2rem;
-  padding: 0rem 0.5rem;
-}
-.titulo::before {
-  height: 12px;
-  width: 12px;
-
-  border: solid $--color-primary;;
-  border-width: 0px 3px 3px 0;
-  margin-bottom: 4px;
-  margin-right: 5px;
-  transform: rotate(130deg);
-  content: "";
-  display: inline-block;
+  padding: 0rem 2rem;
 }
 
 .tema {


### PR DESCRIPTION
Adiciona o carregamento ao entrar na página da proposição;
Remove ícone e funcionalidade de navegação de volta, uma vez que ta na página da proposição, para a listagem ao clicar no nome da proposição.